### PR TITLE
feat(test): API-only global setup + auth storage (refs #10)

### DIFF
--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,201 @@
+import { request } from '@playwright/test';
+import { execSync } from 'child_process';
+import { TEST_CONTENT, TESTTAG_PLUGIN, TEST_URLS, TEST_USERS } from './constants';
+import { WordPressRestClient } from './helpers/wp-api';
+
+/**
+ * Global setup for Playwright tests
+ * 
+ * This runs once before all tests and:
+ * - Ensures the plugin is active
+ * - Creates a test user
+ * - Configures plugin settings
+ */
+
+const baseURL = process.env.TEST_URL || 'http://localhost:8080';
+const isDockerMode = ['true', '1', 'yes'].includes((process.env.USE_DOCKER || '').trim().toLowerCase());
+const PRETTY_PERMALINK_STRUCTURE = '/%postname%/';
+
+const FIXTURE_PAGE_CONTENT =
+  '<!-- wp:html --><h2 data-testid="fixture-subtitle" data-cy="fixture-subtitle" data-test="fixture-subtitle">TestTag Layer Fixture</h2><!-- /wp:html -->' +
+  '<!-- wp:html --><form class="search-form" role="search"><label for="fix-s">Search</label><input id="fix-s" type="search" name="s" /></form><!-- /wp:html -->' +
+  '<!-- wp:paragraph --><p>This page contains representative elements for each TestTag layer.</p><!-- /wp:paragraph -->';
+
+async function waitForWordPressReady(timeoutMs: number = 120000): Promise<void> {
+  console.log('Waiting for WordPress to become ready...');
+  const deadline = Date.now() + timeoutMs;
+  const api = await request.newContext({ baseURL: baseURL, ignoreHTTPSErrors: true });
+
+  try {
+    while (Date.now() < deadline) {
+      try {
+        const response = await api.get(TEST_URLS.LOGIN, { failOnStatusCode: false });
+        if (response.status() >= 200 && response.status() < 500) {
+          console.log(`WordPress is ready (status: ${response.status()}).`);
+          return;
+        }
+      } catch {
+        // Keep polling until timeout while container networking settles.
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+  } finally {
+    await api.dispose();
+  }
+
+  throw new Error(`WordPress did not become ready within ${timeoutMs}ms.`);
+}
+
+async function assertFixturePermalinkExists(): Promise<void> {
+  const api = await request.newContext({ baseURL: baseURL, ignoreHTTPSErrors: true });
+
+  try {
+    const response = await api.get(TEST_URLS.LAYER_FIXTURE_PAGE, { failOnStatusCode: false });
+    if (response.status() === 404) {
+      throw new Error(
+        `Fixture page ${TEST_URLS.LAYER_FIXTURE_PAGE} returned 404 after setup. Setup may have failed.`
+      );
+    }
+    console.log('Fixture page is accessible.');
+  } finally {
+    await api.dispose();
+  }
+}
+
+async function assertFixturePermalinkExistsWithRetry(client: WordPressRestClient): Promise<void> {
+  try {
+    await assertFixturePermalinkExists();
+    return;
+  } catch {
+    console.log('Fixture permalink missing on first check. Reapplying permalink settings...');
+    await client.ensurePrettyPermalinks(PRETTY_PERMALINK_STRUCTURE);
+    await assertFixturePermalinkExists();
+  }
+}
+
+/**
+ * API-based setup - No browser needed
+ */
+async function setupViaApi(): Promise<void> {
+  console.log('Setting up WordPress via REST API...');
+  
+  const api = new WordPressRestClient(baseURL);
+  
+  try {
+    console.log('Ensuring WordPress is installed...');
+    await api.init(TEST_USERS.ADMIN.username, TEST_USERS.ADMIN.password);
+    await api.ensureInstalled({
+      siteTitle: 'TestTag Screenshot Tests',
+      username: TEST_USERS.ADMIN.username,
+      password: TEST_USERS.ADMIN.password,
+      email: TEST_USERS.ADMIN.email,
+    });
+    await api.dispose();
+
+    // Initialize API with admin credentials and establish authenticated session
+    console.log('Authenticating via API...');
+    await api.init(TEST_USERS.ADMIN.username, TEST_USERS.ADMIN.password);
+    const authPath = await api.saveAuthStorage();
+    console.log(`Saved auth storage for ${TEST_USERS.ADMIN.username} at ${authPath}`);
+    
+    // Activate TestTag plugin
+    console.log(`Activating ${TESTTAG_PLUGIN.slug} plugin...`);
+    try {
+      await api.activatePlugin(TESTTAG_PLUGIN.slug);
+      console.log('TestTag plugin activated.');
+    } catch (error) {
+      // Some local stacks do not expose the plugins REST endpoint.
+      console.log('Plugin activation endpoint unavailable in this environment; continuing with existing plugin state.');
+      console.log(`Activation detail: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    
+    // Set pretty permalinks to /%postname%/ and flush rewrite rules.
+    console.log('Configuring permalink structure...');
+    await api.ensurePrettyPermalinks(PRETTY_PERMALINK_STRUCTURE);
+    console.log(`Permalink structure set to ${PRETTY_PERMALINK_STRUCTURE}`);
+    
+    // Update TestTag attribute key to data-testid for consistent fixture expectations
+    console.log('Configuring TestTag settings...');
+    try {
+      await api.updateOption('testtag_attribute_key', 'data-testid');
+      console.log('TestTag attribute key set to data-testid');
+    } catch (error) {
+      // Settings validation might fail if plugin structure is different, log but continue
+      console.log(`Note: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    
+    // Ensure test fixture page
+    console.log('Ensuring test fixture page...');
+    
+    await api.ensurePage({
+      slug: TEST_CONTENT.LAYER_FIXTURE_PAGE_SLUG,
+      title: TEST_CONTENT.LAYER_FIXTURE_PAGE_TITLE,
+      content: FIXTURE_PAGE_CONTENT,
+      status: 'publish',
+    });
+    console.log('Test fixture page ensured.');
+    
+    await assertFixturePermalinkExistsWithRetry(api);
+
+    console.log('WordPress API setup complete!');
+  } finally {
+    await api.dispose();
+  }
+}
+
+/**
+ * Global setup function
+ */
+async function globalSetup(): Promise<void> {
+  // Skip setup in non-Docker CI environments.
+  if (process.env.CI && !isDockerMode) {
+    console.log('Skipping setup in CI mode');
+    return;
+  }
+
+  // Build plugin assets before deployment
+  console.log('Building plugin assets...');
+  try {
+    execSync('npm run build', { stdio: 'inherit' });
+    console.log('Plugin assets built successfully!');
+  } catch (error) {
+    console.error('Build failed:', error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+
+  if (isDockerMode) {
+    // Check if both required services are already running.
+    let servicesRunning = false;
+    try {
+      const psOutput = execSync('docker compose ps --services --filter status=running', {
+        encoding: 'utf8',
+      });
+      const runningServices = psOutput
+        .split(/\r?\n/)
+        .map(s => s.trim())
+        .filter(Boolean);
+      servicesRunning = runningServices.includes('wordpress') && runningServices.includes('mysql');
+    } catch {
+      servicesRunning = false;
+    }
+
+    if (servicesRunning) {
+      // If services are already running, restart WordPress to pick up fresh plugin builds.
+      console.log('Docker services already running. Restarting WordPress to load updated plugin...');
+      execSync('docker compose restart wordpress', { stdio: 'inherit' });
+    } else {
+      // Start containers when any required service is missing.
+      console.log('Starting Docker services...');
+      execSync('docker compose up -d', { stdio: 'inherit' });
+    }
+
+    await waitForWordPressReady();
+  }
+
+  await setupViaApi();
+
+  console.log('Global setup completed successfully!');
+}
+
+export default globalSetup;

--- a/tests/helpers/wp-api.ts
+++ b/tests/helpers/wp-api.ts
@@ -1,0 +1,428 @@
+import { request, type APIRequestContext } from '@playwright/test';
+import path from 'path';
+import { mkdirSync } from 'fs';
+
+type PagePayload = {
+  slug: string;
+  title: string;
+  content: string;
+  status?: 'publish' | 'draft' | 'private';
+};
+
+type InstallPayload = {
+  siteTitle: string;
+  username: string;
+  password: string;
+  email: string;
+};
+
+export class WordPressApiBase {
+  protected readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  protected buildRestEndpoint(root: string, route: string): string {
+    const normalizedRoute = `/${route.replace(/^\/+/, '')}`;
+    const url = new URL(root, `${this.baseUrl}/`);
+
+    if (url.searchParams.has('rest_route')) {
+      url.searchParams.set('rest_route', normalizedRoute);
+      return url.toString();
+    }
+
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}${normalizedRoute}`;
+    url.search = '';
+    return url.toString();
+  }
+
+  protected getCandidateRestRoots(primaryRoot: string): string[] {
+    const fallbackRoots = [
+      `${this.baseUrl}/wp-json/`,
+      `${this.baseUrl}/index.php?rest_route=/`,
+      `${this.baseUrl}/?rest_route=/`,
+    ];
+
+    const normalizedPrimary = primaryRoot
+      ? (primaryRoot.startsWith('http')
+          ? primaryRoot
+          : new URL(primaryRoot, `${this.baseUrl}/`).toString())
+      : '';
+
+    return [...new Set([normalizedPrimary, ...fallbackRoots].filter(Boolean))];
+  }
+}
+
+/**
+ * REST API client for WordPress - all operations via API, no browser needed
+ */
+export class WordPressRestClient extends WordPressApiBase {
+  private api: APIRequestContext | null = null;
+  private ownsApi: boolean = false;
+  private currentUser: string | null = null;
+
+  constructor(baseUrl: string, apiContext?: APIRequestContext) {
+    super(baseUrl);
+    this.api = apiContext || null;
+    this.ownsApi = !apiContext;
+  }
+
+  private getAuthStoragePath(username: string): string {
+    return path.join(process.cwd(), 'tests', '.auth', `${username}-auth.json`);
+  }
+
+  private async ensureAuthenticatedAdminSession(): Promise<void> {
+    const api = this.getApi();
+    const response = await api.get('/wp-admin/', { failOnStatusCode: false });
+    const html = await response.text();
+    if (response.url().includes('/wp-admin/install.php') || html.includes('id="setup"')) {
+      throw new Error('WordPress is not installed yet. Run ensureInstalled() before authentication.');
+    }
+    const redirectedToLogin = response.url().includes('/wp-login.php') || html.includes('id="loginform"');
+    if (redirectedToLogin) {
+      throw new Error('WordPress authentication failed: /wp-admin/ resolved to login page.');
+    }
+  }
+
+  async ensureInstalled(payload: InstallPayload): Promise<void> {
+    const api = this.getApi();
+
+    const adminResponse = await api.get('/wp-admin/', { failOnStatusCode: false });
+    const adminHtml = await adminResponse.text();
+    const installNeeded =
+      adminResponse.url().includes('/wp-admin/install.php') ||
+      adminHtml.includes('id="setup"') ||
+      adminHtml.includes('WordPress &rsaquo; Installation');
+
+    if (!installNeeded) {
+      return;
+    }
+
+    // Step through installer entirely via HTTP form submissions.
+    await api.get('/wp-admin/install.php?step=1', { failOnStatusCode: false });
+    const installResponse = await api.post('/wp-admin/install.php?step=2', {
+      form: {
+        weblog_title: payload.siteTitle,
+        user_name: payload.username,
+        admin_password: payload.password,
+        admin_password2: payload.password,
+        admin_email: payload.email,
+        blog_public: '0',
+        Submit: 'Install WordPress',
+        pw_weak: '1',
+        language: 'en_US',
+      },
+      failOnStatusCode: false,
+    });
+
+    const body = await installResponse.text();
+    const success = body.includes('Success!') || body.includes('WordPress has been installed');
+    if (!success) {
+      throw new Error(`WordPress installation failed with status ${installResponse.status()}.`);
+    }
+  }
+
+  async init(username: string, password: string): Promise<void> {
+    if (this.api && !this.ownsApi) {
+      // If using a provided context, just verify we can access it
+      this.currentUser = username;
+      return;
+    }
+
+    this.api = await request.newContext({
+      baseURL: this.baseUrl,
+      ignoreHTTPSErrors: true,
+    });
+
+    // First, visit login page to establish session
+    await this.api.get('/wp-login.php', { failOnStatusCode: false });
+
+    // Perform login
+    const loginResponse = await this.api.post('/wp-login.php', {
+      form: {
+        log: username,
+        pwd: password,
+        rememberme: 'forever',
+        'wp-submit': 'Log In',
+        redirect_to: `${this.baseUrl}/wp-admin/`,
+        testcookie: '1',
+      },
+      failOnStatusCode: false,
+    });
+
+    // Login responses may be 200 or 302. Both can be valid - the important part
+    // is that cookies are set for subsequent requests.
+    const statusCode = loginResponse.status();
+    if (statusCode >= 400) {
+      throw new Error(`WordPress API login failed with status ${statusCode}`);
+    }
+
+    this.currentUser = username;
+  }
+
+  async initFromAuthStorage(username: string): Promise<void> {
+    this.api = await request.newContext({
+      baseURL: this.baseUrl,
+      ignoreHTTPSErrors: true,
+      storageState: this.getAuthStoragePath(username),
+    });
+
+    this.ownsApi = true;
+    this.currentUser = username;
+    await this.ensureAuthenticatedAdminSession();
+  }
+
+  async saveAuthStorage(username?: string): Promise<string> {
+    const user = username || this.currentUser;
+    if (!user) {
+      throw new Error('No username available to save auth storage.');
+    }
+
+    const api = this.getApi();
+    const authPath = this.getAuthStoragePath(user);
+    mkdirSync(path.dirname(authPath), { recursive: true });
+    await api.storageState({ path: authPath });
+    return authPath;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.api && this.ownsApi) {
+      await this.api.dispose();
+    }
+    this.api = null;
+  }
+
+  private getApi(): APIRequestContext {
+    if (!this.api) {
+      throw new Error('API not initialized. Call init() first or pass APIRequestContext to constructor.');
+    }
+    return this.api;
+  }
+
+  async getRestBootstrap(): Promise<{ candidateRoots: string[]; nonce: string }> {
+    const api = this.getApi();
+    
+    // Try to get nonce from an authenticated admin endpoint
+    const response = await api.get('/wp-admin/', { failOnStatusCode: false });
+    const html = await response.text();
+
+    // Extract REST root from HTML
+    const rootMatch = html.match(/"rest_root":"([^"]+)"/);
+    const nonceMatch = html.match(/"nonce":"([^"]+)"/);
+
+    if (!nonceMatch) {
+      throw new Error('Unable to extract nonce from wp-admin. WordPress may not be installed or user not authenticated.');
+    }
+
+    const root = rootMatch ? rootMatch[1].replace(/\\\//g, '/') : '';
+    const nonce = nonceMatch[1];
+
+    return {
+      candidateRoots: this.getCandidateRestRoots(root),
+      nonce,
+    };
+  }
+
+  async activatePlugin(pluginSlug: string): Promise<void> {
+    const api = this.getApi();
+    const { candidateRoots, nonce } = await this.getRestBootstrap();
+    const errors: string[] = [];
+
+    for (const root of candidateRoots) {
+      const endpoint = new URL(
+        this.buildRestEndpoint(root, `wp/v2/plugins/${pluginSlug}`)
+      );
+
+      const putResponse = await api.put(endpoint.toString(), {
+        headers: {
+          'X-WP-Nonce': nonce,
+          'Content-Type': 'application/json',
+        },
+        data: {
+          status: 'active',
+        },
+        failOnStatusCode: false,
+      });
+
+      if (putResponse.ok()) {
+        return;
+      }
+
+      // Some Apache/PHP setups disallow PUT. Retry with POST override.
+      const postOverrideResponse = await api.post(endpoint.toString(), {
+        headers: {
+          'X-WP-Nonce': nonce,
+          'X-HTTP-Method-Override': 'PUT',
+          'Content-Type': 'application/json',
+        },
+        data: {
+          status: 'active',
+        },
+        failOnStatusCode: false,
+      });
+
+      if (postOverrideResponse.ok()) {
+        return;
+      }
+
+      errors.push(`activate ${root} -> PUT ${putResponse.status()} / POST-override ${postOverrideResponse.status()}`);
+    }
+
+    throw new Error(
+      `Failed to activate plugin ${pluginSlug}. Tried roots: ${candidateRoots.join(', ')}. Errors: ${errors.join('; ')}`
+    );
+  }
+
+  async updateOption(optionName: string, optionValue: unknown): Promise<void> {
+    const api = this.getApi();
+    const { candidateRoots, nonce } = await this.getRestBootstrap();
+    const errors: string[] = [];
+
+    for (const root of candidateRoots) {
+      const endpoint = new URL(
+        this.buildRestEndpoint(root, `wp/v2/settings`)
+      );
+
+      const response = await api.post(endpoint.toString(), {
+        headers: {
+          'X-WP-Nonce': nonce,
+          'Content-Type': 'application/json',
+        },
+        data: {
+          [optionName]: optionValue,
+        },
+        failOnStatusCode: false,
+      });
+
+      if (response.ok()) {
+        return;
+      }
+
+      errors.push(`update ${root} -> ${response.status()}`);
+    }
+
+    throw new Error(
+      `Failed to update option ${optionName}. Tried roots: ${candidateRoots.join(', ')}. Errors: ${errors.join('; ')}`
+    );
+  }
+
+  async getOption(optionName: string): Promise<unknown> {
+    const api = this.getApi();
+    const { candidateRoots, nonce } = await this.getRestBootstrap();
+    const errors: string[] = [];
+
+    for (const root of candidateRoots) {
+      const endpoint = new URL(
+        this.buildRestEndpoint(root, `wp/v2/settings`)
+      );
+
+      const response = await api.get(endpoint.toString(), {
+        headers: {
+          'X-WP-Nonce': nonce,
+        },
+        failOnStatusCode: false,
+      });
+
+      if (!response.ok()) {
+        errors.push(`get ${root} -> ${response.status()}`);
+        continue;
+      }
+
+      const data = (await response.json()) as Record<string, unknown>;
+      return data[optionName];
+    }
+
+    throw new Error(
+      `Failed to get settings. Tried roots: ${candidateRoots.join(', ')}. Errors: ${errors.join('; ')}`
+    );
+  }
+
+  async ensurePage(payload: PagePayload): Promise<void> {
+    const api = this.getApi();
+    const { candidateRoots, nonce } = await this.getRestBootstrap();
+    const errors: string[] = [];
+
+    for (const root of candidateRoots) {
+      const listEndpoint = new URL(this.buildRestEndpoint(root, 'wp/v2/pages'));
+      listEndpoint.searchParams.set('slug', payload.slug);
+      listEndpoint.searchParams.set('_fields', 'id');
+
+      const listResponse = await api.get(listEndpoint.toString(), {
+        headers: {
+          'X-WP-Nonce': nonce,
+        },
+        failOnStatusCode: false,
+      });
+
+      if (!listResponse.ok()) {
+        errors.push(`list ${root} -> ${listResponse.status()}`);
+        continue;
+      }
+
+      const existingPages = (await listResponse.json()) as Array<{ id: number }>;
+
+      const saveEndpoint = existingPages.length
+        ? this.buildRestEndpoint(root, `wp/v2/pages/${existingPages[0].id}`)
+        : this.buildRestEndpoint(root, 'wp/v2/pages');
+
+      const saveResponse = await api.post(saveEndpoint, {
+        headers: {
+          'X-WP-Nonce': nonce,
+          'Content-Type': 'application/json',
+        },
+        data: {
+          title: payload.title,
+          slug: payload.slug,
+          status: payload.status || 'publish',
+          content: payload.content,
+        },
+        failOnStatusCode: false,
+      });
+
+      if (saveResponse.ok()) {
+        return;
+      }
+
+      errors.push(`save ${root} -> ${saveResponse.status()}`);
+    }
+
+    throw new Error(
+      `Failed to ensure page '${payload.slug}' via REST API. Tried roots: ${candidateRoots.join(', ')}. Errors: ${errors.join('; ')}`
+    );
+  }
+
+  async ensurePrettyPermalinks(structure: string = '/%postname%/'): Promise<void> {
+    try {
+      await this.updateOption('permalink_structure', structure);
+    } catch {
+      // Some WordPress setups require the legacy admin form to flush rewrite rules.
+    }
+
+    const api = this.getApi();
+    const settingsPage = await api.get('/wp-admin/options-permalink.php', { failOnStatusCode: false });
+    const html = await settingsPage.text();
+    const nonceMatch = html.match(/name="_wpnonce"\s+value="([^"]+)"/);
+
+    if (!nonceMatch) {
+      throw new Error('Unable to find permalink settings nonce in options-permalink.php.');
+    }
+
+    const saveResponse = await api.post('/wp-admin/options-permalink.php', {
+      form: {
+        _wpnonce: nonceMatch[1],
+        _wp_http_referer: '/wp-admin/options-permalink.php',
+        permalink_structure: structure,
+        category_base: '',
+        tag_base: '',
+        submit: 'Save Changes',
+      },
+      failOnStatusCode: false,
+    });
+
+    const saveHtml = await saveResponse.text();
+    if (saveResponse.status() >= 400 || saveHtml.includes('id="loginform"')) {
+      throw new Error(`Failed to save permalink settings via admin form: ${saveResponse.status()}`);
+    }
+  }
+}


### PR DESCRIPTION
Closes #10\n\n## What\n- APIRequestContext-first helper changes\n- Per-user auth storage save/load in API helper\n- API-only global setup flow\n\n## Notes\nThis PR is scoped only to Task 2 files.