### PR TITLE
Enhance HTML element support and improve testing coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to TestTag for WordPress are documented in this file.
 
+## [Unreleased] — Extended Element Type Tagging Coverage
+
+### Fixed / Added
+
+- **Expanded auto-tagging to cover all common HTML elements** in both the PHP processor and JS dynamic injector. Previously untagged elements and their generated tag formats:
+  - `<ul>` / `<ol>` → `list-{aria-label|id|heading}`; `<li>` → `item-{aria-label|id|text}` (previously only tagged inside custom select lists)
+  - `<table>` → `table-{aria-label|id|caption}`; `<tr>` → `row-{position}`; `<th>` → `col-{text}`; `<td>` → `cell-{column}`
+  - `<option>` → `option-{select-name}-{value}` (native select options were not tagged at all)
+  - `<nav>` → `nav-{aria-label|id|heading}` (was missing from targets entirely)
+  - `<fieldset>` → `fieldset-{aria-label|id|legend}`; `<details>` → `details-{aria-label|id|summary}`; `<summary>` → `summary-{aria-label|id|text}`; `<figure>` → `figure-{aria-label|id|figcaption}`
+
+---
+
 ## [Unreleased] — Configurable Test Tag String Format
 
 ### Settings UI — Tag Format Builder

--- a/includes/class-testtag-html-processor.php
+++ b/includes/class-testtag-html-processor.php
@@ -562,9 +562,9 @@ class TestTag_HTML_Processor {
         if ( $tag === 'option' ) {
             $value    = $el->getAttribute( 'value' );
             $optValue = ( $value !== '' ) ? $value : ( $text_fallback ? trim( $el->textContent ) : '' );
-            if ( ! $optValue ) return null;
+            if ( $optValue === '' ) return null;
             $optSlug  = self::slug( $optValue );
-            if ( ! $optSlug ) return null;
+            if ( $optSlug === '' ) return null;
             // Find the parent <select>
             $selectEl = $el->parentNode;
             while ( $selectEl instanceof DOMElement && strtolower( $selectEl->tagName ) !== 'select' ) {

--- a/includes/class-testtag-html-processor.php
+++ b/includes/class-testtag-html-processor.php
@@ -267,19 +267,21 @@ class TestTag_HTML_Processor {
     private static function auto_generate( DOMDocument $doc, DOMXPath $xpath ): void {
         $targets_xp = implode( ' | ', [
             '//a', '//button',
-            '//input', '//textarea', '//select', '//form',
-            '//section', '//article', '//aside', '//main', '//header', '//footer',
+            '//input', '//textarea', '//select', '//option', '//form',
+            '//section', '//article', '//aside', '//main', '//header', '//footer', '//nav',
             '//h1', '//h2', '//h3', '//h4', '//h5', '//h6',
             '//p',
             '//img',
+            '//ul', '//ol', '//li',
+            '//table', '//tr', '//th', '//td',
+            '//fieldset',
+            '//details', '//summary',
+            '//figure',
             '//*[@id]',
             '//*[@role]',
             '//*[@data-element_type]',
             '//*[@data-widget_type]',
             '//*[contains(@class,"wp-block-")]',
-            '//ul[contains(@class,"select")]//li',
-            '//ul[contains(@class,"options")]//li',
-            '//*[@rel and self::li]',
         ] );
 
         $attr          = self::$attr;
@@ -395,6 +397,22 @@ class TestTag_HTML_Processor {
             return null;
         }
 
+        // ── Navigation ────────────────────────────────────────────
+        if ( $tag === 'nav' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'nav', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'nav', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $h = self::first_heading_text( $el );
+                if ( $h ) return self::format_id( 'nav', self::slug( $h ), $tv );
+            }
+            return null;
+        }
+
         // ── Landmark elements ─────────────────────────────────────
         if ( in_array( $tag, [ 'section', 'article', 'aside', 'main', 'header', 'footer' ], true ) ) {
             $al = $el->getAttribute( 'aria-label' );
@@ -467,35 +485,231 @@ class TestTag_HTML_Processor {
             return $alt ? self::format_id( 'img', self::slug( $alt ), $tv ) : null;
         }
 
-        // ── Custom select options ─────────────────────────────────
-        if ( $tag === 'li' ) {
-            $relVal = $el->getAttribute( 'rel' );
-            $optValue = $relVal ?: ( $text_fallback ? trim( $el->textContent ) : '' );
-            if ( ! $optValue ) return null;
-            $optSlug = self::slug( $optValue );
-            if ( ! $optSlug ) return null;
+        // ── Lists ─────────────────────────────────────────────────
+        if ( $tag === 'ul' || $tag === 'ol' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'list', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'list', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $h = self::first_heading_text( $el );
+                if ( $h ) return self::format_id( 'list', self::slug( $h ), $tv );
+            }
+            return null;
+        }
 
-            // Walk up to find a data-name wrapper or sibling <select>
-            $selectName = null;
-            $parent = $el->parentNode;
-            while ( $parent && $parent instanceof DOMElement ) {
-                if ( $parent->hasAttribute( 'data-name' ) ) {
-                    $selectName = $parent->getAttribute( 'data-name' );
-                    break;
-                }
-                // Look for a sibling or descendant <select>
-                foreach ( $parent->childNodes as $child ) {
-                    if ( $child instanceof DOMElement && $child->tagName === 'select' && $child->hasAttribute( 'name' ) ) {
-                        $selectName = $child->getAttribute( 'name' );
-                        break 2;
+        // ── List items ────────────────────────────────────────────
+        if ( $tag === 'li' ) {
+            $relVal    = $el->getAttribute( 'rel' );
+            $parentEl  = $el->parentNode instanceof DOMElement ? $el->parentNode : null;
+            $parentCls = $parentEl ? $parentEl->getAttribute( 'class' ) : '';
+            $isSelectList = $parentEl && (
+                str_contains( $parentCls, 'select' ) ||
+                str_contains( $parentCls, 'options' )
+            );
+
+            if ( $isSelectList || $relVal ) {
+                // Custom select option — walk up to find a data-name wrapper or sibling <select>
+                $optValue  = $relVal ?: ( $text_fallback ? trim( $el->textContent ) : '' );
+                if ( ! $optValue ) return null;
+                $optSlug   = self::slug( $optValue );
+                if ( ! $optSlug ) return null;
+                $selectName = null;
+                $walker    = $el->parentNode;
+                while ( $walker instanceof DOMElement ) {
+                    if ( $walker->hasAttribute( 'data-name' ) ) {
+                        $selectName = $walker->getAttribute( 'data-name' );
+                        break;
                     }
+                    foreach ( $walker->childNodes as $child ) {
+                        if ( $child instanceof DOMElement && $child->tagName === 'select' && $child->hasAttribute( 'name' ) ) {
+                            $selectName = $child->getAttribute( 'name' );
+                            break 2;
+                        }
+                    }
+                    $walker = $walker->parentNode;
                 }
-                $parent = $parent->parentNode;
+                return $selectName
+                    ? self::format_id( 'option', self::slug( $selectName ) . self::$separator . $optSlug, $tv )
+                    : self::format_id( 'option', $optSlug, $tv );
             }
 
+            // Standard list item
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'item', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'item', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $text = trim( $el->textContent );
+                if ( $text ) return self::format_id( 'item', self::slug( substr( $text, 0, 40 ) ), $tv );
+            }
+            return null;
+        }
+
+        // ── Native select options ─────────────────────────────────
+        if ( $tag === 'option' ) {
+            $value    = $el->getAttribute( 'value' );
+            $optValue = ( $value !== '' ) ? $value : ( $text_fallback ? trim( $el->textContent ) : '' );
+            if ( ! $optValue ) return null;
+            $optSlug  = self::slug( $optValue );
+            if ( ! $optSlug ) return null;
+            // Find the parent <select>
+            $selectEl = $el->parentNode;
+            while ( $selectEl instanceof DOMElement && strtolower( $selectEl->tagName ) !== 'select' ) {
+                $selectEl = $selectEl->parentNode;
+            }
+            $selectName = null;
+            if ( $selectEl instanceof DOMElement ) {
+                $selectName = $selectEl->getAttribute( 'name' ) ?: $selectEl->getAttribute( 'id' );
+            }
             return $selectName
                 ? self::format_id( 'option', self::slug( $selectName ) . self::$separator . $optSlug, $tv )
                 : self::format_id( 'option', $optSlug, $tv );
+        }
+
+        // ── Tables ────────────────────────────────────────────────
+        if ( $tag === 'table' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'table', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'table', $clean, $tv );
+            }
+            $caption = $el->getElementsByTagName( 'caption' )->item( 0 );
+            if ( $caption ) {
+                $text = trim( $caption->textContent );
+                if ( $text ) return self::format_id( 'table', self::slug( $text ), $tv );
+            }
+            if ( $text_fallback ) {
+                $h = self::first_heading_text( $el );
+                if ( $h ) return self::format_id( 'table', self::slug( $h ), $tv );
+            }
+            return null;
+        }
+
+        // ── Table rows ────────────────────────────────────────────
+        if ( $tag === 'tr' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'row', self::slug( $al ), $tv );
+            // Position among sibling <tr> elements (1-indexed)
+            $n    = 1;
+            $prev = $el->previousSibling;
+            while ( $prev ) {
+                if ( $prev instanceof DOMElement && strtolower( $prev->tagName ) === 'tr' ) $n++;
+                $prev = $prev->previousSibling;
+            }
+            return self::format_id( 'row', (string) $n, $tv );
+        }
+
+        // ── Table header cells ────────────────────────────────────
+        if ( $tag === 'th' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'col', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'col', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $text = trim( $el->textContent );
+                if ( $text ) return self::format_id( 'col', self::slug( $text ), $tv );
+            }
+            return null;
+        }
+
+        // ── Table data cells ──────────────────────────────────────
+        if ( $tag === 'td' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'cell', self::slug( $al ), $tv );
+            $headers = $el->getAttribute( 'headers' );
+            if ( $headers ) return self::format_id( 'cell', self::slug( $headers ), $tv );
+            // Column position among siblings (1-indexed)
+            $col  = 1;
+            $prev = $el->previousSibling;
+            while ( $prev ) {
+                if ( $prev instanceof DOMElement && in_array( strtolower( $prev->tagName ), [ 'td', 'th' ], true ) ) $col++;
+                $prev = $prev->previousSibling;
+            }
+            return self::format_id( 'cell', (string) $col, $tv );
+        }
+
+        // ── Fieldsets ─────────────────────────────────────────────
+        if ( $tag === 'fieldset' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'fieldset', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'fieldset', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $legend = $el->getElementsByTagName( 'legend' )->item( 0 );
+                if ( $legend ) {
+                    $text = trim( $legend->textContent );
+                    if ( $text ) return self::format_id( 'fieldset', self::slug( $text ), $tv );
+                }
+            }
+            return null;
+        }
+
+        // ── Details / Summary ─────────────────────────────────────
+        if ( $tag === 'details' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'details', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'details', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $summary = $el->getElementsByTagName( 'summary' )->item( 0 );
+                if ( $summary ) {
+                    $text = trim( $summary->textContent );
+                    if ( $text ) return self::format_id( 'details', self::slug( $text ), $tv );
+                }
+            }
+            return null;
+        }
+
+        if ( $tag === 'summary' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'summary', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'summary', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $text = trim( $el->textContent );
+                if ( $text ) return self::format_id( 'summary', self::slug( $text ), $tv );
+            }
+            return null;
+        }
+
+        // ── Figures ───────────────────────────────────────────────
+        if ( $tag === 'figure' ) {
+            $al = $el->getAttribute( 'aria-label' );
+            if ( $al ) return self::format_id( 'figure', self::slug( $al ), $tv );
+            $id = $el->getAttribute( 'id' );
+            if ( $id ) {
+                $clean = self::clean( self::slug( $id ) );
+                if ( $clean && ! ctype_digit( $clean ) && strlen( $clean ) > 1 ) return self::format_id( 'figure', $clean, $tv );
+            }
+            if ( $text_fallback ) {
+                $figcaption = $el->getElementsByTagName( 'figcaption' )->item( 0 );
+                if ( $figcaption ) {
+                    $text = trim( $figcaption->textContent );
+                    if ( $text ) return self::format_id( 'figure', self::slug( $text ), $tv );
+                }
+            }
+            return null;
         }
 
         // ── Divs / spans ──────────────────────────────────────────

--- a/includes/class-testtag-html-processor.php
+++ b/includes/class-testtag-html-processor.php
@@ -352,7 +352,10 @@ class TestTag_HTML_Processor {
                 $al = $el->getAttribute( 'aria-label' );
                 if ( $al ) return self::format_id( 'nav', self::slug( $al ), $tv );
                 if ( $href === '/' ) return self::format_id( 'nav', 'home', $tv );
-                if ( str_starts_with( $href, '#' ) ) return self::format_id( 'nav', self::slug( substr( $href, 1 ) ), $tv );
+                if ( str_starts_with( $href, '#' ) ) {
+                    $frag = self::slug( substr( $href, 1 ) );
+                    if ( $frag ) return self::format_id( 'nav', $frag, $tv );
+                }
                 $frag = self::href_path_fragment( $href );
                 if ( $frag ) return self::format_id( 'nav', $frag, $tv );
                 if ( $text_fallback ) return self::format_id( 'nav', self::slug( $linkText ?: $href ), $tv );
@@ -392,7 +395,10 @@ class TestTag_HTML_Processor {
             }
             $frag = self::href_path_fragment( $href );
             if ( $frag ) return self::format_id( 'link', $frag, $tv );
-            if ( str_starts_with( $href, '#' ) ) return self::format_id( 'link', self::slug( substr( $href, 1 ) ), $tv );
+            if ( str_starts_with( $href, '#' ) ) {
+                $frag = self::slug( substr( $href, 1 ) );
+                if ( $frag ) return self::format_id( 'link', $frag, $tv );
+            }
             if ( $text_fallback && $linkText ) return self::format_id( 'link', self::slug( $linkText ), $tv );
             return null;
         }

--- a/js/dynamic-injector.js
+++ b/js/dynamic-injector.js
@@ -324,8 +324,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('button', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('button', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('button', cleanedId, details);
             }
             var name = el.getAttribute('name');
             if (name) return formatId('button', slug(name), details);
@@ -380,8 +380,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('link', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('link', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('link', cleanedId, details);
             }
             var frag = hrefPathFragment(href);
             if (frag) return formatId('link', frag, details);
@@ -398,8 +398,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId(tagName, slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId(tagName, idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId(tagName, cleanedId, details);
             }
             if (textFallback) {
                 var h = firstHeadingText(el);
@@ -413,8 +413,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('heading', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('heading', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('heading', cleanedId, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim();
@@ -440,8 +440,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('form', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('form', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('form', cleanedId, details);
             }
             if (textFallback) {
                 var legend = el.querySelector('legend') || el.querySelector('h1,h2,h3,h4,h5,h6');
@@ -464,8 +464,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('nav', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('nav', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('nav', cleanedId, details);
             }
             if (textFallback) {
                 var h = firstHeadingText(el);
@@ -479,8 +479,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('list', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('list', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('list', cleanedId, details);
             }
             if (textFallback) {
                 var h = firstHeadingText(el);
@@ -522,8 +522,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('item', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('item', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('item', cleanedId, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim().slice(0, 40);
@@ -555,8 +555,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('table', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('table', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('table', cleanedId, details);
             }
             var caption = el.querySelector('caption');
             if (caption) {
@@ -588,8 +588,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('col', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('col', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('col', cleanedId, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim();
@@ -619,8 +619,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('fieldset', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('fieldset', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('fieldset', cleanedId, details);
             }
             if (textFallback) {
                 var legend = el.querySelector('legend');
@@ -637,8 +637,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('details', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('details', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('details', cleanedId, details);
             }
             if (textFallback) {
                 var summary = el.querySelector('summary');
@@ -654,8 +654,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('summary', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('summary', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('summary', cleanedId, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim();
@@ -669,8 +669,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('figure', slug(al), details);
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('figure', idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId('figure', cleanedId, details);
             }
             if (textFallback) {
                 var figcaption = el.querySelector('figcaption');
@@ -693,8 +693,8 @@
 
             // 2. Stable id (non-numeric)
             if (el.id) {
-                var idSlug = cleanId(el.id);
-                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId(prefix, idSlug, details);
+                var cleanedId = cleanId(el.id);
+                if (cleanedId && !/^\d+$/.test(cleanedId) && cleanedId.length > 1) return formatId(prefix, cleanedId, details);
             }
 
             // 3. Elementor section/container

--- a/js/dynamic-injector.js
+++ b/js/dynamic-injector.js
@@ -305,7 +305,10 @@
                 var al = el.getAttribute('aria-label');
                 if (al) return formatId('nav', slug(al), details);
                 if (href === '/')               return formatId('nav', 'home', details);
-                if (href.startsWith('#'))       return formatId('nav', slug(href.slice(1)), details);
+                if (href.startsWith('#')) {
+                    var frag = slug(href.slice(1));
+                    if (frag) return formatId('nav', frag, details);
+                }
                 var frag = hrefPathFragment(href);
                 if (frag) return formatId('nav', frag, details);
                 if (textFallback) return formatId('nav', slug(linkText || href), details);
@@ -340,7 +343,10 @@
             }
             var frag = hrefPathFragment(href);
             if (frag) return formatId('link', frag, details);
-            if (href.startsWith('#'))   return formatId('link', slug(href.slice(1)), details);
+            if (href.startsWith('#')) {
+                var frag = slug(href.slice(1));
+                if (frag) return formatId('link', frag, details);
+            }
             if (textFallback && linkText) return formatId('link', slug(linkText), details);
             return null;
         }

--- a/js/dynamic-injector.js
+++ b/js/dynamic-injector.js
@@ -61,6 +61,48 @@
             .slice(0, 50);
     }
 
+    // Mirrors PHP clean() — strips common framework prefixes and noise segments
+    // from a slugified string so ID-derived tags stay meaningful.
+    var CLEAN_PREFIXES = [
+        'core' + separator, 'woocommerce' + separator, 'wc' + separator,
+        'wpcf7' + separator + 'f', 'gform' + separator, 'gfield' + separator,
+        'wp' + separator, 'wordpress' + separator
+    ];
+    var CLEAN_SEGMENTS = [
+        'elementor', 'woocommerce', 'wc', 'core',
+        'divi', 'avada', 'betheme', 'flatsome', 'astra', 'generatepress',
+        'oceanwp', 'hello', 'twentytwentyfour', 'twentytwentythree',
+        'twentytwentytwo', 'twentytwentyone', 'twentytwenty',
+        'widget', 'module', 'block', 'section', 'container', 'wrapper',
+        'inner', 'outer', 'holder'
+    ];
+    var sepEsc = separator === '-' ? '\\-' : separator;
+    var segRe  = new RegExp(
+        '(?:^|' + sepEsc + ')(' + CLEAN_SEGMENTS.join('|') + ')(?=' + sepEsc + '|$)',
+        'g'
+    );
+    var multiSepRe = new RegExp(sepEsc + '{2,}', 'g');
+    var trimSepRe  = new RegExp('^' + sepEsc + '+|' + sepEsc + '+$', 'g');
+
+    function clean(s) {
+        if (!s) return s;
+        for (var i = 0; i < CLEAN_PREFIXES.length; i++) {
+            if (s.indexOf(CLEAN_PREFIXES[i]) === 0) {
+                s = s.slice(CLEAN_PREFIXES[i].length);
+                break;
+            }
+        }
+        s = s.replace(segRe, '');
+        s = s.replace(multiSepRe, separator);
+        s = s.replace(trimSepRe, '');
+        return s;
+    }
+
+    // Convenience: slugify then clean an element ID, matching PHP clean(slug($id)).
+    function cleanId(id) {
+        return clean(slug(id));
+    }
+
     /**
      * Builds a formatted tag value from a semantic type and an identifier,
      * applying the configured separator and type position.
@@ -282,7 +324,7 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('button', slug(al), details);
             if (el.id) {
-                var idSlug = slug(el.id);
+                var idSlug = cleanId(el.id);
                 if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('button', idSlug, details);
             }
             var name = el.getAttribute('name');
@@ -338,7 +380,7 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('link', slug(al), details);
             if (el.id) {
-                var idSlug = slug(el.id);
+                var idSlug = cleanId(el.id);
                 if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('link', idSlug, details);
             }
             var frag = hrefPathFragment(href);
@@ -356,8 +398,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId(tagName, slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId(tagName, clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId(tagName, idSlug, details);
             }
             if (textFallback) {
                 var h = firstHeadingText(el);
@@ -371,8 +413,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('heading', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('heading', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('heading', idSlug, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim();
@@ -398,8 +440,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('form', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('form', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('form', idSlug, details);
             }
             if (textFallback) {
                 var legend = el.querySelector('legend') || el.querySelector('h1,h2,h3,h4,h5,h6');
@@ -422,8 +464,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('nav', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('nav', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('nav', idSlug, details);
             }
             if (textFallback) {
                 var h = firstHeadingText(el);
@@ -437,8 +479,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('list', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('list', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('list', idSlug, details);
             }
             if (textFallback) {
                 var h = firstHeadingText(el);
@@ -480,8 +522,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('item', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('item', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('item', idSlug, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim().slice(0, 40);
@@ -513,8 +555,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('table', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('table', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('table', idSlug, details);
             }
             var caption = el.querySelector('caption');
             if (caption) {
@@ -546,8 +588,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('col', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('col', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('col', idSlug, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim();
@@ -577,8 +619,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('fieldset', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('fieldset', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('fieldset', idSlug, details);
             }
             if (textFallback) {
                 var legend = el.querySelector('legend');
@@ -595,8 +637,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('details', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('details', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('details', idSlug, details);
             }
             if (textFallback) {
                 var summary = el.querySelector('summary');
@@ -612,8 +654,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('summary', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('summary', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('summary', idSlug, details);
             }
             if (textFallback) {
                 var text = el.textContent.trim();
@@ -627,8 +669,8 @@
             var al = el.getAttribute('aria-label');
             if (al) return formatId('figure', slug(al), details);
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('figure', clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId('figure', idSlug, details);
             }
             if (textFallback) {
                 var figcaption = el.querySelector('figcaption');
@@ -651,8 +693,8 @@
 
             // 2. Stable id (non-numeric)
             if (el.id) {
-                var clean = slug(el.id);
-                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId(prefix, clean, details);
+                var idSlug = cleanId(el.id);
+                if (idSlug && !/^\d+$/.test(idSlug) && idSlug.length > 1) return formatId(prefix, idSlug, details);
             }
 
             // 3. Elementor section/container

--- a/js/dynamic-injector.js
+++ b/js/dynamic-injector.js
@@ -411,28 +411,227 @@
             return alt ? formatId('img', slug(alt), details) : null;
         }
 
-        // Custom select options (li inside a select-like list)
+        // Navigation
+        if (tagName === 'nav') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('nav', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('nav', clean, details);
+            }
+            if (textFallback) {
+                var h = firstHeadingText(el);
+                if (h) return formatId('nav', slug(h), details);
+            }
+            return null;
+        }
+
+        // Lists (ul / ol)
+        if (tagName === 'ul' || tagName === 'ol') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('list', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('list', clean, details);
+            }
+            if (textFallback) {
+                var h = firstHeadingText(el);
+                if (h) return formatId('list', slug(h), details);
+            }
+            return null;
+        }
+
+        // List items
         if (tagName === 'li') {
-            var relVal = el.getAttribute('rel');
-            var optValue = relVal || (textFallback ? el.textContent.trim() : '');
+            var relVal     = el.getAttribute('rel');
+            var parentEl   = el.parentElement;
+            var parentCls  = parentEl ? (parentEl.className || '') : '';
+            var isSelectList = parentEl && (parentCls.indexOf('select') !== -1 || parentCls.indexOf('options') !== -1);
+
+            if (isSelectList || relVal) {
+                // Custom select option
+                var optValue = relVal || (textFallback ? el.textContent.trim() : '');
+                if (!optValue) return null;
+                var optSlug = slug(optValue);
+                if (!optSlug) return null;
+                var selectName = null;
+                var walker = el.parentElement;
+                while (walker) {
+                    if (walker.hasAttribute('data-name')) {
+                        selectName = walker.getAttribute('data-name');
+                        break;
+                    }
+                    var sel = walker.querySelector(':scope > select[name]');
+                    if (sel) { selectName = sel.getAttribute('name'); break; }
+                    walker = walker.parentElement;
+                }
+                return selectName
+                    ? formatId('option', slug(selectName) + separator + optSlug, details)
+                    : formatId('option', optSlug, details);
+            }
+
+            // Standard list item
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('item', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('item', clean, details);
+            }
+            if (textFallback) {
+                var text = el.textContent.trim().slice(0, 40);
+                if (text) return formatId('item', slug(text), details);
+            }
+            return null;
+        }
+
+        // Native select options
+        if (tagName === 'option') {
+            var value    = el.getAttribute('value');
+            var optValue = (value !== null && value !== '') ? value : (textFallback ? el.textContent.trim() : '');
             if (!optValue) return null;
             var optSlug = slug(optValue);
             if (!optSlug) return null;
-            // Walk up to find a data-name wrapper or sibling <select>
-            var selectName = null;
-            var parent = el.parentElement;
-            while (parent) {
-                if (parent.hasAttribute('data-name')) {
-                    selectName = parent.getAttribute('data-name');
-                    break;
-                }
-                var sel = parent.querySelector(':scope > select[name]');
-                if (sel) { selectName = sel.getAttribute('name'); break; }
-                parent = parent.parentElement;
+            // Find the parent <select>
+            var selectEl = el.parentElement;
+            while (selectEl && selectEl.tagName.toLowerCase() !== 'select') {
+                selectEl = selectEl.parentElement;
             }
+            var selectName = selectEl ? (selectEl.getAttribute('name') || selectEl.id || '') : '';
             return selectName
                 ? formatId('option', slug(selectName) + separator + optSlug, details)
                 : formatId('option', optSlug, details);
+        }
+
+        // Tables
+        if (tagName === 'table') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('table', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('table', clean, details);
+            }
+            var caption = el.querySelector('caption');
+            if (caption) {
+                var text = caption.textContent.trim();
+                if (text) return formatId('table', slug(text), details);
+            }
+            if (textFallback) {
+                var h = firstHeadingText(el);
+                if (h) return formatId('table', slug(h), details);
+            }
+            return null;
+        }
+
+        // Table rows
+        if (tagName === 'tr') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('row', slug(al), details);
+            var n = 1;
+            var prev = el.previousElementSibling;
+            while (prev) {
+                if (prev.tagName.toLowerCase() === 'tr') n++;
+                prev = prev.previousElementSibling;
+            }
+            return formatId('row', String(n), details);
+        }
+
+        // Table header cells
+        if (tagName === 'th') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('col', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('col', clean, details);
+            }
+            if (textFallback) {
+                var text = el.textContent.trim();
+                if (text) return formatId('col', slug(text), details);
+            }
+            return null;
+        }
+
+        // Table data cells
+        if (tagName === 'td') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('cell', slug(al), details);
+            var headers = el.getAttribute('headers');
+            if (headers) return formatId('cell', slug(headers), details);
+            var col = 1;
+            var prev = el.previousElementSibling;
+            while (prev) {
+                var prevTag = prev.tagName.toLowerCase();
+                if (prevTag === 'td' || prevTag === 'th') col++;
+                prev = prev.previousElementSibling;
+            }
+            return formatId('cell', String(col), details);
+        }
+
+        // Fieldsets
+        if (tagName === 'fieldset') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('fieldset', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('fieldset', clean, details);
+            }
+            if (textFallback) {
+                var legend = el.querySelector('legend');
+                if (legend) {
+                    var text = legend.textContent.trim();
+                    if (text) return formatId('fieldset', slug(text), details);
+                }
+            }
+            return null;
+        }
+
+        // Details / Summary
+        if (tagName === 'details') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('details', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('details', clean, details);
+            }
+            if (textFallback) {
+                var summary = el.querySelector('summary');
+                if (summary) {
+                    var text = summary.textContent.trim();
+                    if (text) return formatId('details', slug(text), details);
+                }
+            }
+            return null;
+        }
+
+        if (tagName === 'summary') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('summary', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('summary', clean, details);
+            }
+            if (textFallback) {
+                var text = el.textContent.trim();
+                if (text) return formatId('summary', slug(text), details);
+            }
+            return null;
+        }
+
+        // Figures
+        if (tagName === 'figure') {
+            var al = el.getAttribute('aria-label');
+            if (al) return formatId('figure', slug(al), details);
+            if (el.id) {
+                var clean = slug(el.id);
+                if (clean && !/^\d+$/.test(clean) && clean.length > 1) return formatId('figure', clean, details);
+            }
+            if (textFallback) {
+                var figcaption = el.querySelector('figcaption');
+                if (figcaption) {
+                    var text = figcaption.textContent.trim();
+                    if (text) return formatId('figure', slug(text), details);
+                }
+            }
+            return null;
         }
 
         // Divs / spans — stable-first: aria-label → id → Elementor/Gutenberg attrs → role
@@ -501,16 +700,19 @@
     // ── Selector target list (mirrors PHP auto_generate targets) ──
     var AUTO_SELECTOR = [
         'a', 'button',
-        'input', 'textarea', 'select', 'form',
-        'section', 'article', 'aside', 'main', 'header', 'footer',
+        'input', 'textarea', 'select', 'option', 'form',
+        'section', 'article', 'aside', 'main', 'header', 'footer', 'nav',
         'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
         'p',
         'img',
+        'ul', 'ol', 'li',
+        'table', 'tr', 'th', 'td',
+        'fieldset',
+        'details', 'summary',
+        'figure',
         '[id]', '[role]',
         '[data-element_type]', '[data-widget_type]',
         '[class*="wp-block-"]',
-        'ul[class*="select"] li', 'ul[class*="options"] li',
-        'li[rel]',
     ].join(', ');
 
     // ── Process a newly added subtree ─────────────────────────────

--- a/tests/e2e/frontend-audit/element-tagging.spec.ts
+++ b/tests/e2e/frontend-audit/element-tagging.spec.ts
@@ -1,446 +1,192 @@
 import { test, expect } from '@tests/fixtures';
-import { FrontendPage } from '@pageObjects/FrontendPage';
-import { TEST_URLS } from '@tests/constants';
+import { TestPage } from '@pageObjects/TestPage';
 
 /**
  * Element Type Tagging — Auto Layer Coverage
  *
  * Verifies that every HTML element type handled by the auto-generate layer
- * receives a tag on the fixture page.  Tests are organised by element
- * category.  For each element we assert:
+ * receives a tag on the fixture page.  Each test:
  *
- *   1. data-testtag-layer="auto" is present (the plugin tagged it)
- *   2. The configured test attribute carries the expected value
+ *   1. Locates the element via its expected tag value (page.getByTestId),
+ *      which implicitly verifies the correct tag was generated.
+ *   2. Asserts data-testtag-layer="auto" to confirm the auto layer tagged it.
  *
- * Stable identifiers (aria-label / id / position-based) use exact-value
- * assertions.  Text-fallback elements use a /^{type}-/ prefix match so
- * minor wording changes do not break the suite.
- *
- * Tag derivation reference (default separator "-"):
- *   get_label_text:  label[for] → aria-label → aria-labelledby
- *   form controls:   label text → name → placeholder
- *   headings:        aria-label → id → text content (fallback)
- *   landmarks:       aria-label → id → first heading (fallback)
- *   lists/tables:    aria-label → id → caption/heading (fallback) / position
+ * All locators live on TestPage so tag values are maintained in one place.
  */
 test.describe('Element type tagging — auto layer coverage', () => {
+  let testPage: TestPage;
+
   test.beforeEach(async ({ page }) => {
-    const frontendPage = new FrontendPage(page);
-    await frontendPage.open(TEST_URLS.LAYER_FIXTURE_PAGE);
+    testPage = new TestPage(page);
+    await testPage.open();
   });
 
   // ── Links ────────────────────────────────────────────────────────────────────
 
-  test('a: regular link is tagged link-{aria-label}', async ({ page, testTagSettings }) => {
-    // <a href="/contact" aria-label="Contact us"> in #fixture-auto-sample
-    const link = page.locator('#fixture-auto-sample a[aria-label="Contact us"]');
-
-    await test.step('link has data-testtag-layer="auto"', async () => {
-      await expect(link).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('link tag is link-contact-us (from aria-label)', async () => {
-      await expect(link).toHaveAttribute(testTagSettings.attributeKey, 'link-contact-us');
-    });
+  test('a: href="#" falls through to text fallback and is tagged', async () => {
+    await expect(testPage.primaryLink()).toBeVisible();
+    await expect(testPage.primaryLink()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('a: nav link is tagged nav-{fragment}', async ({ page, testTagSettings }) => {
-    // <a href="#fixture-inline-sample"> inside <nav aria-label="Primary">
-    const navLink = page.locator('#fixture-primary-nav a').first();
-
-    await test.step('nav link has data-testtag-layer="auto"', async () => {
-      await expect(navLink).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('nav link tag starts with nav-', async () => {
-      const tag = await navLink.getAttribute(testTagSettings.attributeKey);
-      expect(tag).toMatch(/^nav-/);
-    });
+  test('a: nav link is tagged with nav- prefix', async () => {
+    await expect(testPage.firstNavLink()).toBeVisible();
+    await expect(testPage.firstNavLink()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Buttons ──────────────────────────────────────────────────────────────────
 
-  test('button: is tagged button-{text}', async ({ page, testTagSettings }) => {
-    // <button type="button">Button action</button> in #fixture-auto-sample
-    const btn = page.locator('#fixture-auto-sample button[type="button"]');
-
-    await test.step('button has data-testtag-layer="auto"', async () => {
-      await expect(btn).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('button tag is button-button-action (from text content)', async () => {
-      await expect(btn).toHaveAttribute(testTagSettings.attributeKey, 'button-button-action');
-    });
+  test('button: is tagged from text content', async () => {
+    await expect(testPage.actionButton()).toBeVisible();
+    await expect(testPage.actionButton()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Form controls ────────────────────────────────────────────────────────────
 
-  test('input: email input is tagged input-{aria-label}', async ({ page, testTagSettings }) => {
-    // <input type="email" aria-label="Email input"> in #fixture-auto-sample
-    const input = page.locator('#fixture-auto-sample input[type="email"]');
-
-    await test.step('input has data-testtag-layer="auto"', async () => {
-      await expect(input).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('input tag is input-email-input (from aria-label via get_label_text)', async () => {
-      await expect(input).toHaveAttribute(testTagSettings.attributeKey, 'input-email-input');
-    });
+  test('input: is tagged from aria-label', async () => {
+    await expect(testPage.emailInput()).toBeVisible();
+    await expect(testPage.emailInput()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('textarea: is tagged textarea-{aria-label}', async ({ page, testTagSettings }) => {
-    // <textarea aria-label="Sample textarea"> in #fixture-auto-sample
-    const textarea = page.locator('#fixture-auto-sample textarea');
-
-    await test.step('textarea has data-testtag-layer="auto"', async () => {
-      await expect(textarea).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('textarea tag is textarea-sample-textarea (from aria-label)', async () => {
-      await expect(textarea).toHaveAttribute(testTagSettings.attributeKey, 'textarea-sample-textarea');
-    });
+  test('textarea: is tagged from aria-label', async () => {
+    await expect(testPage.sampleTextarea()).toBeVisible();
+    await expect(testPage.sampleTextarea()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('select: is tagged select-{aria-label}', async ({ page, testTagSettings }) => {
-    // <select id="fixture-select" aria-label="Sample select"> in #fixture-auto-sample
-    const select = page.locator('#fixture-select');
-
-    await test.step('select has data-testtag-layer="auto"', async () => {
-      await expect(select).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('select tag is select-sample-select (from aria-label)', async () => {
-      await expect(select).toHaveAttribute(testTagSettings.attributeKey, 'select-sample-select');
-    });
+  test('select: is tagged from aria-label', async () => {
+    await expect(testPage.sampleSelect()).toBeVisible();
+    await expect(testPage.sampleSelect()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('form: is tagged form-{aria-label}', async ({ page, testTagSettings }) => {
-    // <form id="fixture-form" aria-label="Contact form"> in #fixture-content-extras
-    const form = page.locator('#fixture-form');
+  test('form: is tagged from aria-label', async () => {
+    await expect(testPage.contactForm()).toBeVisible();
+    await expect(testPage.contactForm()).toHaveAttribute('data-testtag-layer', 'auto');
+  });
 
-    await test.step('form has data-testtag-layer="auto"', async () => {
-      await expect(form).toHaveAttribute('data-testtag-layer', 'auto');
-    });
+  test('option: is tagged from select name and value attribute', async () => {
+    await expect(testPage.firstSelectOption()).toHaveAttribute('data-testtag-layer', 'auto');
+  });
 
-    await test.step('form tag is form-contact-form (from aria-label)', async () => {
-      await expect(form).toHaveAttribute(testTagSettings.attributeKey, 'form-contact-form');
-    });
+  test('fieldset: is tagged from id', async () => {
+    await expect(testPage.fieldset()).toBeVisible();
+    await expect(testPage.fieldset()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Headings ─────────────────────────────────────────────────────────────────
 
-  test('h1: is tagged heading-{text}', async ({ page, testTagSettings }) => {
-    // <h1>Common Site Elements + Layer Samples</h1> in #fixture-site-header
-    const h1 = page.locator('#fixture-site-header h1');
-
-    await test.step('h1 has data-testtag-layer="auto"', async () => {
-      await expect(h1).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('h1 tag is heading-common-site-elements-layer-samples', async () => {
-      await expect(h1).toHaveAttribute(
-        testTagSettings.attributeKey,
-        'heading-common-site-elements-layer-samples',
-      );
-    });
+  test('h1: is tagged from text content', async () => {
+    await expect(testPage.siteH1()).toBeVisible();
+    await expect(testPage.siteH1()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('h2: is tagged heading-{text}', async ({ page, testTagSettings }) => {
-    // <h2>Selector-map Layer Sample</h2> in #fixture-selector-sample (no pre-authored attrs)
-    const h2 = page.locator('#fixture-selector-sample h2');
-
-    await test.step('h2 has data-testtag-layer="auto"', async () => {
-      await expect(h2).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('h2 tag is heading-selector-map-layer-sample (from text)', async () => {
-      await expect(h2).toHaveAttribute(
-        testTagSettings.attributeKey,
-        'heading-selector-map-layer-sample',
-      );
-    });
+  test('h2: is tagged from text content', async () => {
+    await expect(testPage.selectorMapH2()).toBeVisible();
+    await expect(testPage.selectorMapH2()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Paragraphs ───────────────────────────────────────────────────────────────
 
-  test('p: is tagged text-{nearest-tagged-ancestor}', async ({ page, testTagSettings }) => {
-    // <p> in #fixture-inline-sample; nearest tagged ancestor is #fixture-inline-sample
-    // which gets section-fixture-inline-sample, so p gets text-section-fixture-inline-sample
-    const p = page.locator('#fixture-inline-sample p');
-
-    await test.step('p has data-testtag-layer="auto"', async () => {
-      await expect(p).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('p tag starts with text-', async () => {
-      const tag = await p.getAttribute(testTagSettings.attributeKey);
-      expect(tag).toMatch(/^text-/);
-    });
+  test('p: is tagged using nearest tagged ancestor as prefix', async () => {
+    await expect(testPage.inlineParagraph()).toBeVisible();
+    await expect(testPage.inlineParagraph()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Media ────────────────────────────────────────────────────────────────────
 
-  test('img: is tagged img-{alt}', async ({ page, testTagSettings }) => {
-    // <img alt="Placeholder graphic"> in #fixture-sidebar figure
-    const img = page.locator('#fixture-sidebar img');
-
-    await test.step('img has data-testtag-layer="auto"', async () => {
-      await expect(img).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('img tag is img-placeholder-graphic (from alt attribute)', async () => {
-      await expect(img).toHaveAttribute(testTagSettings.attributeKey, 'img-placeholder-graphic');
-    });
+  test('img: is tagged from alt attribute', async () => {
+    await expect(testPage.sidebarImage()).toBeVisible();
+    await expect(testPage.sidebarImage()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Landmark elements ────────────────────────────────────────────────────────
 
-  test('header: is tagged header-{id}', async ({ page, testTagSettings }) => {
-    const header = page.locator('#fixture-site-header');
-
-    await test.step('header has data-testtag-layer="auto"', async () => {
-      await expect(header).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('header tag is header-fixture-site-header (from id)', async () => {
-      await expect(header).toHaveAttribute(testTagSettings.attributeKey, 'header-fixture-site-header');
-    });
+  test('header: is tagged from id', async () => {
+    await expect(testPage.siteHeader()).toBeVisible();
+    await expect(testPage.siteHeader()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('nav: is tagged nav-{aria-label}', async ({ page, testTagSettings }) => {
-    const nav = page.locator('#fixture-primary-nav');
-
-    await test.step('nav has data-testtag-layer="auto"', async () => {
-      await expect(nav).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('nav tag is nav-primary (from aria-label="Primary")', async () => {
-      await expect(nav).toHaveAttribute(testTagSettings.attributeKey, 'nav-primary');
-    });
+  test('nav: is tagged from aria-label', async () => {
+    await expect(testPage.primaryNav()).toBeVisible();
+    await expect(testPage.primaryNav()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('main: is tagged main-{id}', async ({ page, testTagSettings }) => {
-    const main = page.locator('#fixture-main');
-
-    await test.step('main has data-testtag-layer="auto"', async () => {
-      await expect(main).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('main tag is main-fixture-main (from id)', async () => {
-      await expect(main).toHaveAttribute(testTagSettings.attributeKey, 'main-fixture-main');
-    });
+  test('main: is tagged from id', async () => {
+    await expect(testPage.mainContent()).toBeVisible();
+    await expect(testPage.mainContent()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('section: is tagged section-{id}', async ({ page, testTagSettings }) => {
-    const section = page.locator('#fixture-inline-sample');
-
-    await test.step('section has data-testtag-layer="auto"', async () => {
-      await expect(section).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('section tag is section-fixture-inline-sample (from id)', async () => {
-      await expect(section).toHaveAttribute(
-        testTagSettings.attributeKey,
-        'section-fixture-inline-sample',
-      );
-    });
+  test('section: is tagged from id', async () => {
+    await expect(testPage.inlineSection()).toBeVisible();
+    await expect(testPage.inlineSection()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('article: is tagged article-{aria-label}', async ({ page, testTagSettings }) => {
-    // <article id="fixture-content" aria-label="Main content">
-    const article = page.locator('#fixture-content');
-
-    await test.step('article has data-testtag-layer="auto"', async () => {
-      await expect(article).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('article tag is article-main-content (from aria-label)', async () => {
-      await expect(article).toHaveAttribute(testTagSettings.attributeKey, 'article-main-content');
-    });
+  test('article: is tagged from aria-label', async () => {
+    await expect(testPage.contentArticle()).toBeVisible();
+    await expect(testPage.contentArticle()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('aside: is tagged aside-{aria-label}', async ({ page, testTagSettings }) => {
-    // <aside id="fixture-sidebar" aria-label="Sidebar">
-    const aside = page.locator('#fixture-sidebar');
-
-    await test.step('aside has data-testtag-layer="auto"', async () => {
-      await expect(aside).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('aside tag is aside-sidebar (from aria-label)', async () => {
-      await expect(aside).toHaveAttribute(testTagSettings.attributeKey, 'aside-sidebar');
-    });
+  test('aside: is tagged from aria-label', async () => {
+    await expect(testPage.sidebarAside()).toBeVisible();
+    await expect(testPage.sidebarAside()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('footer: is tagged footer-{id}', async ({ page, testTagSettings }) => {
-    const footer = page.locator('#fixture-footer');
-
-    await test.step('footer has data-testtag-layer="auto"', async () => {
-      await expect(footer).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('footer tag is footer-fixture-footer (from id)', async () => {
-      await expect(footer).toHaveAttribute(testTagSettings.attributeKey, 'footer-fixture-footer');
-    });
+  test('footer: is tagged from id', async () => {
+    await expect(testPage.siteFooter()).toBeVisible();
+    await expect(testPage.siteFooter()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Lists ────────────────────────────────────────────────────────────────────
 
-  test('ul: is tagged list-{id}', async ({ page, testTagSettings }) => {
-    const ul = page.locator('#fixture-ul');
-
-    await test.step('ul has data-testtag-layer="auto"', async () => {
-      await expect(ul).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('ul tag is list-fixture-ul (from id)', async () => {
-      await expect(ul).toHaveAttribute(testTagSettings.attributeKey, 'list-fixture-ul');
-    });
+  test('ul: is tagged from id', async () => {
+    await expect(testPage.unorderedList()).toBeVisible();
+    await expect(testPage.unorderedList()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('ol: is tagged list-{id}', async ({ page, testTagSettings }) => {
-    const ol = page.locator('#fixture-ol');
-
-    await test.step('ol has data-testtag-layer="auto"', async () => {
-      await expect(ol).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('ol tag is list-fixture-ol (from id)', async () => {
-      await expect(ol).toHaveAttribute(testTagSettings.attributeKey, 'list-fixture-ol');
-    });
+  test('ol: is tagged from id', async () => {
+    await expect(testPage.orderedList()).toBeVisible();
+    await expect(testPage.orderedList()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('li: standard list item is tagged item-{text}', async ({ page, testTagSettings }) => {
-    const li = page.locator('#fixture-ul li').first();
-
-    await test.step('li has data-testtag-layer="auto"', async () => {
-      await expect(li).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('li tag starts with item-', async () => {
-      const tag = await li.getAttribute(testTagSettings.attributeKey);
-      expect(tag).toMatch(/^item-/);
-    });
+  test('li: standard list item is tagged from text content', async () => {
+    await expect(testPage.firstListItem()).toBeVisible();
+    await expect(testPage.firstListItem()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
   // ── Tables ───────────────────────────────────────────────────────────────────
 
-  test('table: is tagged table-{id}', async ({ page, testTagSettings }) => {
-    const table = page.locator('#fixture-table');
-
-    await test.step('table has data-testtag-layer="auto"', async () => {
-      await expect(table).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('table tag is table-fixture-table (from id)', async () => {
-      await expect(table).toHaveAttribute(testTagSettings.attributeKey, 'table-fixture-table');
-    });
+  test('table: is tagged from id', async () => {
+    await expect(testPage.metricsTable()).toBeVisible();
+    await expect(testPage.metricsTable()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('tr: is tagged row-{position}', async ({ page, testTagSettings }) => {
-    const tr = page.locator('#fixture-table thead tr').first();
-
-    await test.step('tr has data-testtag-layer="auto"', async () => {
-      await expect(tr).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('tr tag is row-1 (first sibling position)', async () => {
-      await expect(tr).toHaveAttribute(testTagSettings.attributeKey, 'row-1');
-    });
+  test('tr: is tagged from sibling position, scoped to parent table', async () => {
+    await expect(testPage.tableHeaderRow()).toBeVisible();
+    await expect(testPage.tableHeaderRow()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('th: is tagged col-{text}', async ({ page, testTagSettings }) => {
-    const th = page.locator('#fixture-table th').first();
-
-    await test.step('th has data-testtag-layer="auto"', async () => {
-      await expect(th).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('th tag starts with col-', async () => {
-      const tag = await th.getAttribute(testTagSettings.attributeKey);
-      expect(tag).toMatch(/^col-/);
-    });
+  test('th: is tagged from text content', async () => {
+    await expect(testPage.firstTableHeaderCell()).toBeVisible();
+    await expect(testPage.firstTableHeaderCell()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('td: is tagged cell-{column-position}', async ({ page, testTagSettings }) => {
-    const td = page.locator('#fixture-table tbody td').first();
-
-    await test.step('td has data-testtag-layer="auto"', async () => {
-      await expect(td).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('td tag is cell-1 (first column)', async () => {
-      await expect(td).toHaveAttribute(testTagSettings.attributeKey, 'cell-1');
-    });
+  test('td: is tagged from column position, scoped to parent table', async () => {
+    await expect(testPage.firstTableDataCell()).toBeVisible();
+    await expect(testPage.firstTableDataCell()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  // ── Select options ───────────────────────────────────────────────────────────
+  // ── Details / Summary / Figure ───────────────────────────────────────────────
 
-  test('option: is tagged option-{select-name}-{value}', async ({ page, testTagSettings }) => {
-    // <option value="option-a"> inside <select name="fixture-select">
-    const option = page.locator('#fixture-select option').first();
-
-    await test.step('option has data-testtag-layer="auto"', async () => {
-      await expect(option).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('option tag is option-fixture-select-option-a (select name + value)', async () => {
-      await expect(option).toHaveAttribute(
-        testTagSettings.attributeKey,
-        'option-fixture-select-option-a',
-      );
-    });
+  test('details: is tagged from id', async () => {
+    await expect(testPage.detailsDisclosure()).toBeVisible();
+    await expect(testPage.detailsDisclosure()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  // ── Fieldset / Details / Figure ──────────────────────────────────────────────
-
-  test('fieldset: is tagged fieldset-{id}', async ({ page, testTagSettings }) => {
-    const fieldset = page.locator('#fixture-fieldset');
-
-    await test.step('fieldset has data-testtag-layer="auto"', async () => {
-      await expect(fieldset).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('fieldset tag is fieldset-fixture-fieldset (from id)', async () => {
-      await expect(fieldset).toHaveAttribute(testTagSettings.attributeKey, 'fieldset-fixture-fieldset');
-    });
+  test('summary: is tagged from text content', async () => {
+    await expect(testPage.detailsSummary()).toBeVisible();
+    await expect(testPage.detailsSummary()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 
-  test('details: is tagged details-{id}', async ({ page, testTagSettings }) => {
-    const details = page.locator('#fixture-details');
-
-    await test.step('details has data-testtag-layer="auto"', async () => {
-      await expect(details).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('details tag is details-fixture-details (from id)', async () => {
-      await expect(details).toHaveAttribute(testTagSettings.attributeKey, 'details-fixture-details');
-    });
-  });
-
-  test('summary: is tagged summary-{text}', async ({ page, testTagSettings }) => {
-    const summary = page.locator('#fixture-details summary');
-
-    await test.step('summary has data-testtag-layer="auto"', async () => {
-      await expect(summary).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('summary tag starts with summary-', async () => {
-      const tag = await summary.getAttribute(testTagSettings.attributeKey);
-      expect(tag).toMatch(/^summary-/);
-    });
-  });
-
-  test('figure: is tagged figure-{figcaption}', async ({ page, testTagSettings }) => {
-    const figure = page.locator('#fixture-sidebar figure');
-
-    await test.step('figure has data-testtag-layer="auto"', async () => {
-      await expect(figure).toHaveAttribute('data-testtag-layer', 'auto');
-    });
-
-    await test.step('figure tag starts with figure-', async () => {
-      const tag = await figure.getAttribute(testTagSettings.attributeKey);
-      expect(tag).toMatch(/^figure-/);
-    });
+  test('figure: is tagged from figcaption text', async () => {
+    await expect(testPage.sidebarFigure()).toBeVisible();
+    await expect(testPage.sidebarFigure()).toHaveAttribute('data-testtag-layer', 'auto');
   });
 });

--- a/tests/e2e/frontend-audit/element-tagging.spec.ts
+++ b/tests/e2e/frontend-audit/element-tagging.spec.ts
@@ -1,0 +1,446 @@
+import { test, expect } from '@tests/fixtures';
+import { FrontendPage } from '@pageObjects/FrontendPage';
+import { TEST_URLS } from '@tests/constants';
+
+/**
+ * Element Type Tagging — Auto Layer Coverage
+ *
+ * Verifies that every HTML element type handled by the auto-generate layer
+ * receives a tag on the fixture page.  Tests are organised by element
+ * category.  For each element we assert:
+ *
+ *   1. data-testtag-layer="auto" is present (the plugin tagged it)
+ *   2. The configured test attribute carries the expected value
+ *
+ * Stable identifiers (aria-label / id / position-based) use exact-value
+ * assertions.  Text-fallback elements use a /^{type}-/ prefix match so
+ * minor wording changes do not break the suite.
+ *
+ * Tag derivation reference (default separator "-"):
+ *   get_label_text:  label[for] → aria-label → aria-labelledby
+ *   form controls:   label text → name → placeholder
+ *   headings:        aria-label → id → text content (fallback)
+ *   landmarks:       aria-label → id → first heading (fallback)
+ *   lists/tables:    aria-label → id → caption/heading (fallback) / position
+ */
+test.describe('Element type tagging — auto layer coverage', () => {
+  test.beforeEach(async ({ page }) => {
+    const frontendPage = new FrontendPage(page);
+    await frontendPage.open(TEST_URLS.LAYER_FIXTURE_PAGE);
+  });
+
+  // ── Links ────────────────────────────────────────────────────────────────────
+
+  test('a: regular link is tagged link-{aria-label}', async ({ page, testTagSettings }) => {
+    // <a href="/contact" aria-label="Contact us"> in #fixture-auto-sample
+    const link = page.locator('#fixture-auto-sample a[aria-label="Contact us"]');
+
+    await test.step('link has data-testtag-layer="auto"', async () => {
+      await expect(link).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('link tag is link-contact-us (from aria-label)', async () => {
+      await expect(link).toHaveAttribute(testTagSettings.attributeKey, 'link-contact-us');
+    });
+  });
+
+  test('a: nav link is tagged nav-{fragment}', async ({ page, testTagSettings }) => {
+    // <a href="#fixture-inline-sample"> inside <nav aria-label="Primary">
+    const navLink = page.locator('#fixture-primary-nav a').first();
+
+    await test.step('nav link has data-testtag-layer="auto"', async () => {
+      await expect(navLink).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('nav link tag starts with nav-', async () => {
+      const tag = await navLink.getAttribute(testTagSettings.attributeKey);
+      expect(tag).toMatch(/^nav-/);
+    });
+  });
+
+  // ── Buttons ──────────────────────────────────────────────────────────────────
+
+  test('button: is tagged button-{text}', async ({ page, testTagSettings }) => {
+    // <button type="button">Button action</button> in #fixture-auto-sample
+    const btn = page.locator('#fixture-auto-sample button[type="button"]');
+
+    await test.step('button has data-testtag-layer="auto"', async () => {
+      await expect(btn).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('button tag is button-button-action (from text content)', async () => {
+      await expect(btn).toHaveAttribute(testTagSettings.attributeKey, 'button-button-action');
+    });
+  });
+
+  // ── Form controls ────────────────────────────────────────────────────────────
+
+  test('input: email input is tagged input-{aria-label}', async ({ page, testTagSettings }) => {
+    // <input type="email" aria-label="Email input"> in #fixture-auto-sample
+    const input = page.locator('#fixture-auto-sample input[type="email"]');
+
+    await test.step('input has data-testtag-layer="auto"', async () => {
+      await expect(input).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('input tag is input-email-input (from aria-label via get_label_text)', async () => {
+      await expect(input).toHaveAttribute(testTagSettings.attributeKey, 'input-email-input');
+    });
+  });
+
+  test('textarea: is tagged textarea-{aria-label}', async ({ page, testTagSettings }) => {
+    // <textarea aria-label="Sample textarea"> in #fixture-auto-sample
+    const textarea = page.locator('#fixture-auto-sample textarea');
+
+    await test.step('textarea has data-testtag-layer="auto"', async () => {
+      await expect(textarea).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('textarea tag is textarea-sample-textarea (from aria-label)', async () => {
+      await expect(textarea).toHaveAttribute(testTagSettings.attributeKey, 'textarea-sample-textarea');
+    });
+  });
+
+  test('select: is tagged select-{aria-label}', async ({ page, testTagSettings }) => {
+    // <select id="fixture-select" aria-label="Sample select"> in #fixture-auto-sample
+    const select = page.locator('#fixture-select');
+
+    await test.step('select has data-testtag-layer="auto"', async () => {
+      await expect(select).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('select tag is select-sample-select (from aria-label)', async () => {
+      await expect(select).toHaveAttribute(testTagSettings.attributeKey, 'select-sample-select');
+    });
+  });
+
+  test('form: is tagged form-{aria-label}', async ({ page, testTagSettings }) => {
+    // <form id="fixture-form" aria-label="Contact form"> in #fixture-content-extras
+    const form = page.locator('#fixture-form');
+
+    await test.step('form has data-testtag-layer="auto"', async () => {
+      await expect(form).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('form tag is form-contact-form (from aria-label)', async () => {
+      await expect(form).toHaveAttribute(testTagSettings.attributeKey, 'form-contact-form');
+    });
+  });
+
+  // ── Headings ─────────────────────────────────────────────────────────────────
+
+  test('h1: is tagged heading-{text}', async ({ page, testTagSettings }) => {
+    // <h1>Common Site Elements + Layer Samples</h1> in #fixture-site-header
+    const h1 = page.locator('#fixture-site-header h1');
+
+    await test.step('h1 has data-testtag-layer="auto"', async () => {
+      await expect(h1).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('h1 tag is heading-common-site-elements-layer-samples', async () => {
+      await expect(h1).toHaveAttribute(
+        testTagSettings.attributeKey,
+        'heading-common-site-elements-layer-samples',
+      );
+    });
+  });
+
+  test('h2: is tagged heading-{text}', async ({ page, testTagSettings }) => {
+    // <h2>Selector-map Layer Sample</h2> in #fixture-selector-sample (no pre-authored attrs)
+    const h2 = page.locator('#fixture-selector-sample h2');
+
+    await test.step('h2 has data-testtag-layer="auto"', async () => {
+      await expect(h2).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('h2 tag is heading-selector-map-layer-sample (from text)', async () => {
+      await expect(h2).toHaveAttribute(
+        testTagSettings.attributeKey,
+        'heading-selector-map-layer-sample',
+      );
+    });
+  });
+
+  // ── Paragraphs ───────────────────────────────────────────────────────────────
+
+  test('p: is tagged text-{nearest-tagged-ancestor}', async ({ page, testTagSettings }) => {
+    // <p> in #fixture-inline-sample; nearest tagged ancestor is #fixture-inline-sample
+    // which gets section-fixture-inline-sample, so p gets text-section-fixture-inline-sample
+    const p = page.locator('#fixture-inline-sample p');
+
+    await test.step('p has data-testtag-layer="auto"', async () => {
+      await expect(p).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('p tag starts with text-', async () => {
+      const tag = await p.getAttribute(testTagSettings.attributeKey);
+      expect(tag).toMatch(/^text-/);
+    });
+  });
+
+  // ── Media ────────────────────────────────────────────────────────────────────
+
+  test('img: is tagged img-{alt}', async ({ page, testTagSettings }) => {
+    // <img alt="Placeholder graphic"> in #fixture-sidebar figure
+    const img = page.locator('#fixture-sidebar img');
+
+    await test.step('img has data-testtag-layer="auto"', async () => {
+      await expect(img).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('img tag is img-placeholder-graphic (from alt attribute)', async () => {
+      await expect(img).toHaveAttribute(testTagSettings.attributeKey, 'img-placeholder-graphic');
+    });
+  });
+
+  // ── Landmark elements ────────────────────────────────────────────────────────
+
+  test('header: is tagged header-{id}', async ({ page, testTagSettings }) => {
+    const header = page.locator('#fixture-site-header');
+
+    await test.step('header has data-testtag-layer="auto"', async () => {
+      await expect(header).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('header tag is header-fixture-site-header (from id)', async () => {
+      await expect(header).toHaveAttribute(testTagSettings.attributeKey, 'header-fixture-site-header');
+    });
+  });
+
+  test('nav: is tagged nav-{aria-label}', async ({ page, testTagSettings }) => {
+    const nav = page.locator('#fixture-primary-nav');
+
+    await test.step('nav has data-testtag-layer="auto"', async () => {
+      await expect(nav).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('nav tag is nav-primary (from aria-label="Primary")', async () => {
+      await expect(nav).toHaveAttribute(testTagSettings.attributeKey, 'nav-primary');
+    });
+  });
+
+  test('main: is tagged main-{id}', async ({ page, testTagSettings }) => {
+    const main = page.locator('#fixture-main');
+
+    await test.step('main has data-testtag-layer="auto"', async () => {
+      await expect(main).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('main tag is main-fixture-main (from id)', async () => {
+      await expect(main).toHaveAttribute(testTagSettings.attributeKey, 'main-fixture-main');
+    });
+  });
+
+  test('section: is tagged section-{id}', async ({ page, testTagSettings }) => {
+    const section = page.locator('#fixture-inline-sample');
+
+    await test.step('section has data-testtag-layer="auto"', async () => {
+      await expect(section).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('section tag is section-fixture-inline-sample (from id)', async () => {
+      await expect(section).toHaveAttribute(
+        testTagSettings.attributeKey,
+        'section-fixture-inline-sample',
+      );
+    });
+  });
+
+  test('article: is tagged article-{aria-label}', async ({ page, testTagSettings }) => {
+    // <article id="fixture-content" aria-label="Main content">
+    const article = page.locator('#fixture-content');
+
+    await test.step('article has data-testtag-layer="auto"', async () => {
+      await expect(article).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('article tag is article-main-content (from aria-label)', async () => {
+      await expect(article).toHaveAttribute(testTagSettings.attributeKey, 'article-main-content');
+    });
+  });
+
+  test('aside: is tagged aside-{aria-label}', async ({ page, testTagSettings }) => {
+    // <aside id="fixture-sidebar" aria-label="Sidebar">
+    const aside = page.locator('#fixture-sidebar');
+
+    await test.step('aside has data-testtag-layer="auto"', async () => {
+      await expect(aside).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('aside tag is aside-sidebar (from aria-label)', async () => {
+      await expect(aside).toHaveAttribute(testTagSettings.attributeKey, 'aside-sidebar');
+    });
+  });
+
+  test('footer: is tagged footer-{id}', async ({ page, testTagSettings }) => {
+    const footer = page.locator('#fixture-footer');
+
+    await test.step('footer has data-testtag-layer="auto"', async () => {
+      await expect(footer).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('footer tag is footer-fixture-footer (from id)', async () => {
+      await expect(footer).toHaveAttribute(testTagSettings.attributeKey, 'footer-fixture-footer');
+    });
+  });
+
+  // ── Lists ────────────────────────────────────────────────────────────────────
+
+  test('ul: is tagged list-{id}', async ({ page, testTagSettings }) => {
+    const ul = page.locator('#fixture-ul');
+
+    await test.step('ul has data-testtag-layer="auto"', async () => {
+      await expect(ul).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('ul tag is list-fixture-ul (from id)', async () => {
+      await expect(ul).toHaveAttribute(testTagSettings.attributeKey, 'list-fixture-ul');
+    });
+  });
+
+  test('ol: is tagged list-{id}', async ({ page, testTagSettings }) => {
+    const ol = page.locator('#fixture-ol');
+
+    await test.step('ol has data-testtag-layer="auto"', async () => {
+      await expect(ol).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('ol tag is list-fixture-ol (from id)', async () => {
+      await expect(ol).toHaveAttribute(testTagSettings.attributeKey, 'list-fixture-ol');
+    });
+  });
+
+  test('li: standard list item is tagged item-{text}', async ({ page, testTagSettings }) => {
+    const li = page.locator('#fixture-ul li').first();
+
+    await test.step('li has data-testtag-layer="auto"', async () => {
+      await expect(li).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('li tag starts with item-', async () => {
+      const tag = await li.getAttribute(testTagSettings.attributeKey);
+      expect(tag).toMatch(/^item-/);
+    });
+  });
+
+  // ── Tables ───────────────────────────────────────────────────────────────────
+
+  test('table: is tagged table-{id}', async ({ page, testTagSettings }) => {
+    const table = page.locator('#fixture-table');
+
+    await test.step('table has data-testtag-layer="auto"', async () => {
+      await expect(table).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('table tag is table-fixture-table (from id)', async () => {
+      await expect(table).toHaveAttribute(testTagSettings.attributeKey, 'table-fixture-table');
+    });
+  });
+
+  test('tr: is tagged row-{position}', async ({ page, testTagSettings }) => {
+    const tr = page.locator('#fixture-table thead tr').first();
+
+    await test.step('tr has data-testtag-layer="auto"', async () => {
+      await expect(tr).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('tr tag is row-1 (first sibling position)', async () => {
+      await expect(tr).toHaveAttribute(testTagSettings.attributeKey, 'row-1');
+    });
+  });
+
+  test('th: is tagged col-{text}', async ({ page, testTagSettings }) => {
+    const th = page.locator('#fixture-table th').first();
+
+    await test.step('th has data-testtag-layer="auto"', async () => {
+      await expect(th).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('th tag starts with col-', async () => {
+      const tag = await th.getAttribute(testTagSettings.attributeKey);
+      expect(tag).toMatch(/^col-/);
+    });
+  });
+
+  test('td: is tagged cell-{column-position}', async ({ page, testTagSettings }) => {
+    const td = page.locator('#fixture-table tbody td').first();
+
+    await test.step('td has data-testtag-layer="auto"', async () => {
+      await expect(td).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('td tag is cell-1 (first column)', async () => {
+      await expect(td).toHaveAttribute(testTagSettings.attributeKey, 'cell-1');
+    });
+  });
+
+  // ── Select options ───────────────────────────────────────────────────────────
+
+  test('option: is tagged option-{select-name}-{value}', async ({ page, testTagSettings }) => {
+    // <option value="option-a"> inside <select name="fixture-select">
+    const option = page.locator('#fixture-select option').first();
+
+    await test.step('option has data-testtag-layer="auto"', async () => {
+      await expect(option).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('option tag is option-fixture-select-option-a (select name + value)', async () => {
+      await expect(option).toHaveAttribute(
+        testTagSettings.attributeKey,
+        'option-fixture-select-option-a',
+      );
+    });
+  });
+
+  // ── Fieldset / Details / Figure ──────────────────────────────────────────────
+
+  test('fieldset: is tagged fieldset-{id}', async ({ page, testTagSettings }) => {
+    const fieldset = page.locator('#fixture-fieldset');
+
+    await test.step('fieldset has data-testtag-layer="auto"', async () => {
+      await expect(fieldset).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('fieldset tag is fieldset-fixture-fieldset (from id)', async () => {
+      await expect(fieldset).toHaveAttribute(testTagSettings.attributeKey, 'fieldset-fixture-fieldset');
+    });
+  });
+
+  test('details: is tagged details-{id}', async ({ page, testTagSettings }) => {
+    const details = page.locator('#fixture-details');
+
+    await test.step('details has data-testtag-layer="auto"', async () => {
+      await expect(details).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('details tag is details-fixture-details (from id)', async () => {
+      await expect(details).toHaveAttribute(testTagSettings.attributeKey, 'details-fixture-details');
+    });
+  });
+
+  test('summary: is tagged summary-{text}', async ({ page, testTagSettings }) => {
+    const summary = page.locator('#fixture-details summary');
+
+    await test.step('summary has data-testtag-layer="auto"', async () => {
+      await expect(summary).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('summary tag starts with summary-', async () => {
+      const tag = await summary.getAttribute(testTagSettings.attributeKey);
+      expect(tag).toMatch(/^summary-/);
+    });
+  });
+
+  test('figure: is tagged figure-{figcaption}', async ({ page, testTagSettings }) => {
+    const figure = page.locator('#fixture-sidebar figure');
+
+    await test.step('figure has data-testtag-layer="auto"', async () => {
+      await expect(figure).toHaveAttribute('data-testtag-layer', 'auto');
+    });
+
+    await test.step('figure tag starts with figure-', async () => {
+      const tag = await figure.getAttribute(testTagSettings.attributeKey);
+      expect(tag).toMatch(/^figure-/);
+    });
+  });
+});

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -66,7 +66,7 @@ const FIXTURE_PAGE_CONTENT = `<!-- wp:html -->
         <h2 style="margin-bottom:6px;">Auto Layer Sample</h2>
         <p>These are common site controls/elements likely to be auto-tagged:</p>
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px;">
-          <a href="/contact" aria-label="Contact us">Contact</a>
+          <a href="#">Primary link</a>
           <button type="button">Button action</button>
           <input type="email" placeholder="Email input" aria-label="Email input" />
           <select id="fixture-select" name="fixture-select" aria-label="Sample select">

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -110,6 +110,10 @@ const FIXTURE_PAGE_CONTENT = `<!-- wp:html -->
           <summary>Toggle FAQ</summary>
           <p>This is the expanded content.</p>
         </details>
+        <form id="fixture-form" aria-label="Contact form" style="margin-top:12px;padding:10px;border:1px solid #ccc;">
+          <label>Name <input type="text" name="contact-name" placeholder="Your name" /></label>
+          <button type="submit">Send</button>
+        </form>
       </section>
     </article>
 

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -66,12 +66,12 @@ const FIXTURE_PAGE_CONTENT = `<!-- wp:html -->
         <h2 style="margin-bottom:6px;">Auto Layer Sample</h2>
         <p>These are common site controls/elements likely to be auto-tagged:</p>
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px;">
-          <a href="#">Primary link</a>
+          <a href="/contact" aria-label="Contact us">Contact</a>
           <button type="button">Button action</button>
           <input type="email" placeholder="Email input" aria-label="Email input" />
-          <select aria-label="Sample select">
-            <option>Option A</option>
-            <option>Option B</option>
+          <select id="fixture-select" name="fixture-select" aria-label="Sample select">
+            <option value="option-a">Option A</option>
+            <option value="option-b">Option B</option>
           </select>
         </div>
         <textarea rows="3" cols="32" aria-label="Sample textarea">Sample textarea content</textarea>
@@ -85,11 +85,15 @@ const FIXTURE_PAGE_CONTENT = `<!-- wp:html -->
 
       <section id="fixture-content-extras">
         <h2 style="margin-bottom:6px;">Additional Common Content</h2>
-        <ul>
+        <ul id="fixture-ul" style="padding-left:18px;">
           <li>Unordered list item</li>
           <li>Secondary list item</li>
         </ul>
-        <table style="border-collapse:collapse;min-width:260px;">
+        <ol id="fixture-ol" style="padding-left:18px;margin-top:8px;">
+          <li>First ordered item</li>
+          <li>Second ordered item</li>
+        </ol>
+        <table id="fixture-table" style="border-collapse:collapse;min-width:260px;margin-top:8px;">
           <caption style="text-align:left;padding-bottom:4px;">Sample metrics table</caption>
           <thead>
             <tr><th style="border:1px solid #ccc;padding:4px;">Metric</th><th style="border:1px solid #ccc;padding:4px;">Value</th></tr>
@@ -98,6 +102,14 @@ const FIXTURE_PAGE_CONTENT = `<!-- wp:html -->
             <tr><td style="border:1px solid #ccc;padding:4px;">Tagged elements</td><td style="border:1px solid #ccc;padding:4px;">Expected &gt; 0</td></tr>
           </tbody>
         </table>
+        <fieldset id="fixture-fieldset" style="margin-top:12px;border:1px solid #ccc;padding:10px;">
+          <legend>Shipping address</legend>
+          <input type="text" placeholder="Street" aria-label="Street address" />
+        </fieldset>
+        <details id="fixture-details" style="margin-top:12px;">
+          <summary>Toggle FAQ</summary>
+          <p>This is the expanded content.</p>
+        </details>
       </section>
     </article>
 

--- a/tests/pageObjects/TestPage.ts
+++ b/tests/pageObjects/TestPage.ts
@@ -1,0 +1,148 @@
+import type { Locator, Page } from '@playwright/test';
+import { FrontendPage } from '@pageObjects/FrontendPage';
+import { TEST_URLS } from '@tests/constants';
+
+/**
+ * Page object for the seeded layer-fixture page (/test-page/).
+ *
+ * Every locator uses page.getByTestId() with the expected auto-generated tag
+ * value, so the correct test attribute is always used for the active settings
+ * profile (data-testid, data-cy, etc.).
+ *
+ * Where multiple elements share the same generated tag (e.g. row-1, cell-1),
+ * the locator is scoped to its parent element to avoid ambiguity.
+ *
+ * Tag derivation at a glance (default separator "-"):
+ *   aria-label / get_label_text  →  slug              (highest priority)
+ *   id                           →  clean(slug)
+ *   caption / legend / figcaption / summary  →  slug  (text fallback)
+ *   sibling position             →  "1", "2", …       (tr / td)
+ */
+export class TestPage extends FrontendPage {
+  protected pageUrl = TEST_URLS.LAYER_FIXTURE_PAGE;
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override async open(): Promise<void> {
+    await super.open(TEST_URLS.LAYER_FIXTURE_PAGE);
+  }
+
+  // ── Links ──────────────────────────────────────────────────────────────────
+
+  /** <a href="#">Primary link</a> → link-primary-link (empty fragment falls through to text) */
+  primaryLink(): Locator { return this.page.getByTestId('link-primary-link'); }
+
+  /** First <a> inside <nav aria-label="Primary"> → nav-fixture-inline-sample */
+  firstNavLink(): Locator { return this.page.getByTestId('nav-fixture-inline-sample'); }
+
+  // ── Buttons ────────────────────────────────────────────────────────────────
+
+  /** <button type="button">Button action</button> → button-button-action */
+  actionButton(): Locator { return this.page.getByTestId('button-button-action'); }
+
+  // ── Form controls ──────────────────────────────────────────────────────────
+
+  /** <input type="email" aria-label="Email input"> → input-email-input */
+  emailInput(): Locator { return this.page.getByTestId('input-email-input'); }
+
+  /** <textarea aria-label="Sample textarea"> → textarea-sample-textarea */
+  sampleTextarea(): Locator { return this.page.getByTestId('textarea-sample-textarea'); }
+
+  /** <select aria-label="Sample select"> → select-sample-select */
+  sampleSelect(): Locator { return this.page.getByTestId('select-sample-select'); }
+
+  /** <form aria-label="Contact form"> → form-contact-form */
+  contactForm(): Locator { return this.page.getByTestId('form-contact-form'); }
+
+  /** <option value="option-a"> inside #fixture-select → option-fixture-select-option-a */
+  firstSelectOption(): Locator { return this.page.getByTestId('option-fixture-select-option-a'); }
+
+  /** <fieldset id="fixture-fieldset"> → fieldset-fixture-fieldset */
+  fieldset(): Locator { return this.page.getByTestId('fieldset-fixture-fieldset'); }
+
+  // ── Headings ───────────────────────────────────────────────────────────────
+
+  /** <h1>Common Site Elements + Layer Samples</h1> → heading-common-site-elements-layer-samples */
+  siteH1(): Locator { return this.page.getByTestId('heading-common-site-elements-layer-samples'); }
+
+  /** <h2>Selector-map Layer Sample</h2> (no pre-authored attrs) → heading-selector-map-layer-sample */
+  selectorMapH2(): Locator { return this.page.getByTestId('heading-selector-map-layer-sample'); }
+
+  // ── Paragraphs ─────────────────────────────────────────────────────────────
+
+  /** <p> inside #fixture-inline-sample; nearest tagged ancestor → section-fixture-inline-sample */
+  inlineParagraph(): Locator { return this.page.getByTestId('text-section-fixture-inline-sample'); }
+
+  // ── Media ──────────────────────────────────────────────────────────────────
+
+  /** <img alt="Placeholder graphic"> → img-placeholder-graphic */
+  sidebarImage(): Locator { return this.page.getByTestId('img-placeholder-graphic'); }
+
+  /** <figure> in #fixture-sidebar; figcaption "Image and caption sample." → figure-image-and-caption-sample */
+  sidebarFigure(): Locator { return this.page.getByTestId('figure-image-and-caption-sample'); }
+
+  // ── Landmarks ─────────────────────────────────────────────────────────────
+
+  /** <header id="fixture-site-header"> → header-fixture-site-header */
+  siteHeader(): Locator { return this.page.getByTestId('header-fixture-site-header'); }
+
+  /** <nav aria-label="Primary"> → nav-primary */
+  primaryNav(): Locator { return this.page.getByTestId('nav-primary'); }
+
+  /** <main id="fixture-main"> → main-fixture-main */
+  mainContent(): Locator { return this.page.getByTestId('main-fixture-main'); }
+
+  /** <section id="fixture-inline-sample"> → section-fixture-inline-sample */
+  inlineSection(): Locator { return this.page.getByTestId('section-fixture-inline-sample'); }
+
+  /** <article id="fixture-content" aria-label="Main content"> → article-main-content */
+  contentArticle(): Locator { return this.page.getByTestId('article-main-content'); }
+
+  /** <aside id="fixture-sidebar" aria-label="Sidebar"> → aside-sidebar */
+  sidebarAside(): Locator { return this.page.getByTestId('aside-sidebar'); }
+
+  /** <footer id="fixture-footer"> → footer-fixture-footer */
+  siteFooter(): Locator { return this.page.getByTestId('footer-fixture-footer'); }
+
+  // ── Lists ──────────────────────────────────────────────────────────────────
+
+  /** <ul id="fixture-ul"> → list-fixture-ul */
+  unorderedList(): Locator { return this.page.getByTestId('list-fixture-ul'); }
+
+  /** <ol id="fixture-ol"> → list-fixture-ol */
+  orderedList(): Locator { return this.page.getByTestId('list-fixture-ol'); }
+
+  /** First <li> in #fixture-ul; text "Unordered list item" → item-unordered-list-item */
+  firstListItem(): Locator { return this.page.getByTestId('item-unordered-list-item'); }
+
+  // ── Tables ─────────────────────────────────────────────────────────────────
+
+  /** <table id="fixture-table"> → table-fixture-table */
+  metricsTable(): Locator { return this.page.getByTestId('table-fixture-table'); }
+
+  /**
+   * First <tr> in #fixture-table (thead row); sibling position 1 → row-1.
+   * Scoped to the table because multiple tables on a page each produce their
+   * own row-1.
+   */
+  tableHeaderRow(): Locator { return this.metricsTable().getByTestId('row-1').first(); }
+
+  /** First <th>; text "Metric" → col-metric */
+  firstTableHeaderCell(): Locator { return this.page.getByTestId('col-metric'); }
+
+  /**
+   * First <td> in #fixture-table; column position 1 → cell-1.
+   * Scoped to the table because every table row produces its own cell-1.
+   */
+  firstTableDataCell(): Locator { return this.metricsTable().getByTestId('cell-1').first(); }
+
+  // ── Details / Summary ──────────────────────────────────────────────────────
+
+  /** <details id="fixture-details"> → details-fixture-details */
+  detailsDisclosure(): Locator { return this.page.getByTestId('details-fixture-details'); }
+
+  /** <summary>Toggle FAQ</summary> inside #fixture-details → summary-toggle-faq */
+  detailsSummary(): Locator { return this.page.getByTestId('summary-toggle-faq'); }
+}


### PR DESCRIPTION
This pull request significantly expands the auto-tagging coverage in TestTag for WordPress, ensuring that all common HTML elements—including lists, tables, navigation, and form-related elements—receive consistent and descriptive test tags. The changes update both the PHP processor and the JavaScript dynamic injector to generate tags for previously untagged elements, improving testability and accessibility coverage.

**Expanded Element Auto-Tagging:**

* Added support for auto-tagging a wide range of HTML elements, including `<ul>`, `<ol>`, `<li>`, `<table>`, `<tr>`, `<th>`, `<td>`, `<option>`, `<nav>`, `<fieldset>`, `<details>`, `<summary>`, and `<figure>`, with descriptive tag formats based on element attributes or content. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R17) [[2]](diffhunk://#diff-0f91dd1e154a48d68f018a502a70161cc17635f62bfa13a6b4f9b9ea9c9a6ab7L270-L282) [[3]](diffhunk://#diff-0f91dd1e154a48d68f018a502a70161cc17635f62bfa13a6b4f9b9ea9c9a6ab7L470-R720)

**Improvements in Tag Generation Logic:**

* Enhanced logic for generating tags for navigation and link elements to handle fragment identifiers more robustly, avoiding empty slugs. [[1]](diffhunk://#diff-0f91dd1e154a48d68f018a502a70161cc17635f62bfa13a6b4f9b9ea9c9a6ab7L353-R358) [[2]](diffhunk://#diff-0f91dd1e154a48d68f018a502a70161cc17635f62bfa13a6b4f9b9ea9c9a6ab7L393-R421) [[3]](diffhunk://#diff-405c41dbdaefa44e0d9d2e72854ec66554d83663e0cde724d523caf11ae627c4L308-R311) [[4]](diffhunk://#diff-405c41dbdaefa44e0d9d2e72854ec66554d83663e0cde724d523caf11ae627c4L343-R349)

**Refinement of List and Option Tagging:**

* Improved differentiation between standard list items and custom select options, and added native `<option>` tag support with context-aware tag generation (e.g., including the parent select's name or id).

**Table and Form Element Tagging:**

* Added detailed tag generation for table structures, assigning tags to tables, rows, headers, and cells based on position, headers, or content. Fieldsets and related elements now also receive descriptive tags.

**Changelog Documentation:**

* Updated `CHANGELOG.md` to reflect the expanded coverage and new tag formats for these elements.